### PR TITLE
Bugfix for Species Estimation

### DIFF
--- a/proksee/commands/cmd_assemble.py
+++ b/proksee/commands/cmd_assemble.py
@@ -98,7 +98,7 @@ def report_species(species_list):
     if len(species_list) > 1:
         click.echo("\nWARNING: Additional high-confidence species were found in the input data:\n")
 
-        for species in species_list[1:]:
+        for species in species_list[1:min(5, len(species_list))]:
             click.echo(species)
 
     if species.name == "Unknown":  # A species could not be determined.
@@ -234,7 +234,8 @@ def assemble(reads, output_directory, force, species_name=None, platform_name=No
     assembly_database = AssemblyDatabase(DATABASE_PATH)
 
     # Estimate species
-    species_list = utilities.determine_species(filtered_reads, assembly_database, output_directory, species_name)
+    filtered_filenames = filtered_reads.get_file_locations()
+    species_list = utilities.determine_species(filtered_filenames, assembly_database, output_directory, species_name)
     species = species_list[0]
     report_species(species_list)
 

--- a/proksee/commands/cmd_evaluate.py
+++ b/proksee/commands/cmd_evaluate.py
@@ -68,7 +68,7 @@ def evaluate(contigs_filename, output_directory, species_name=None):
     assembly_database = AssemblyDatabase(DATABASE_PATH)
 
     # Estimate species
-    species_list = utilities.determine_species(contigs_filename, assembly_database, output_directory, species_name)
+    species_list = utilities.determine_species([contigs_filename], assembly_database, output_directory, species_name)
     species = species_list[0]
     click.echo("The identified species is: " + str(species.name) + "\n")
 

--- a/proksee/utilities.py
+++ b/proksee/utilities.py
@@ -24,12 +24,12 @@ from proksee.species import Species
 from proksee.species_estimator import SpeciesEstimator
 
 
-def determine_species(input_filename, assembly_database, output_directory, species_name=None):
+def determine_species(input_filenames, assembly_database, output_directory, species_name=None):
     """
     Attempts to determine the species in the input (reads or contigs).
 
     ARGUMENTS:
-        input_filename (string): the input from which to determine the species from
+        input_filenames (List(string)): the inputs (filenames) from which to determine the species from
         assembly_database (AssemblyDatabase): the assembly database
         output_directory (string): the location  of the output directory -- for placing temporary output
         species_name (string): optional; the scientific name of the species
@@ -51,8 +51,7 @@ def determine_species(input_filename, assembly_database, output_directory, speci
     if species_list is None:
         click.echo("\nAttempting to identify the species from the input.")
 
-        input_file_locations = [input_filename]  # Needs to be a list.
-        species_estimator = SpeciesEstimator(input_file_locations, output_directory)
+        species_estimator = SpeciesEstimator(input_filenames, output_directory)
         species_list = species_estimator.estimate_all_species()
 
     return species_list

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -36,11 +36,11 @@ class TestUtilities:
         Tests when the species name is provided, and is present in the database.
         """
 
-        input_filename = os.path.join(INPUT_DIR, "staph_mini.fastq")
+        input_filenames = [os.path.join(INPUT_DIR, "staph_mini.fastq")]
         database = AssemblyDatabase(DATABASE_PATH)
         species_name = "Staphylococcus aureus"
 
-        species_list = determine_species(input_filename, database, OUTPUT_DIR, species_name)
+        species_list = determine_species(input_filenames, database, OUTPUT_DIR, species_name)
         assert(species_list[0] == Species("Staphylococcus aureus", 1.0))
 
     def test_determine_species_provided_absent(self):
@@ -48,11 +48,11 @@ class TestUtilities:
         Tests when the species name is provided, but is not present in the database.
         """
 
-        input_filename = os.path.join(INPUT_DIR, "staph_mini.fastq")
+        input_filenames = [os.path.join(INPUT_DIR, "staph_mini.fastq")]
         database = AssemblyDatabase(DATABASE_PATH)
         species_name = "Staphyl aureus"
 
-        species_list = determine_species(input_filename, database, OUTPUT_DIR, species_name)
+        species_list = determine_species(input_filenames, database, OUTPUT_DIR, species_name)
 
         # Tries to find species when name missing
         assert(species_list[0] == Species("Staphylococcus aureus", 1.0))


### PR DESCRIPTION
There was a problem where the utilities.determine_species(...) function was expecting a filename, but was being passed a read object instead, so Refseq Masher was always failing and the species was being reported as "Unknown".

The related tests were passing because the tests were passing the filename correctly.

Also, changed the way additional major species are output:

```
for species in species_list[1:min(5, len(species_list))]:
    click.echo(species)
```

This is because now that species are being output correctly, there's A LOT of them being estimated at low probability. The above change will limit how many are printed to output, but will not otherwise change the behaviour of assemble.