### PR TITLE
Adding the ability to specify the MASH database download path.

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,1 +1,3 @@
-{"mashPath": "/home/eric/projects/proksee-cmd/temp/refseq.genomes.k21s1000.msh"}
+{
+    "mashPath": ""
+}

--- a/config.json
+++ b/config.json
@@ -1,0 +1,1 @@
+{"mashPath": "/home/eric/projects/proksee-cmd/temp/refseq.genomes.k21s1000.msh"}

--- a/proksee/commands/cmd_assemble.py
+++ b/proksee/commands/cmd_assemble.py
@@ -41,11 +41,6 @@ from proksee.expert_system import ExpertSystem
 from proksee.writer.assembly_statistics_writer import AssemblyStatisticsWriter
 from proksee import config as config
 
-mash_database_path = config.get(config.MASH_PATH)
-
-if not os.path.isfile(mash_database_path):
-    print("Please run 'proksee updatedb' to install the databases!")
-
 DATABASE_PATH = os.path.join(Path(__file__).parent.parent.absolute(), "database",
                              "refseq_short.csv")
 ID_MAPPING_FILENAME = os.path.join(Path(__file__).parent.parent.absolute(), "database",

--- a/proksee/commands/cmd_assemble.py
+++ b/proksee/commands/cmd_assemble.py
@@ -39,11 +39,15 @@ from proksee.platform_identify import PlatformIdentifier, identify_name, Platfor
 from proksee.read_filterer import ReadFilterer
 from proksee.expert_system import ExpertSystem
 from proksee.writer.assembly_statistics_writer import AssemblyStatisticsWriter
+from proksee import config as config
+
+mash_database_path = config.get(config.MASH_PATH)
+
+if not os.path.isfile(mash_database_path):
+    print("Please run 'proksee updatedb' to install the databases!")
 
 DATABASE_PATH = os.path.join(Path(__file__).parent.parent.absolute(), "database",
                              "refseq_short.csv")
-MASH_DATABASE = os.path.join(Path(__file__).parent.parent.absolute(), "database",
-                             "refseq.genomes.k21s1000.msh")
 ID_MAPPING_FILENAME = os.path.join(Path(__file__).parent.parent.absolute(), "database",
                                    "mash_id_mapping.tab.gz")
 
@@ -197,16 +201,18 @@ def determine_platform(reads, platform_name=None):
 def cli(ctx, forward, reverse, output, force, species, platform):
 
     # Check Mash database is installed:
-    if not os.path.isfile(MASH_DATABASE):
+    mash_database_path = config.get(config.MASH_PATH)
+
+    if not os.path.isfile(mash_database_path):
         print("Please run 'proksee updatedb' to install the databases!")
         return
 
     reads = Reads(forward, reverse)
-    assemble(reads, output, force, species, platform)
+    assemble(reads, output, force, mash_database_path, species, platform)
 
 
-def assemble(reads, output_directory, force, species_name=None, platform_name=None,
-             mash_database_filename=MASH_DATABASE,
+def assemble(reads, output_directory, force, mash_database_path,
+             species_name=None, platform_name=None,
              id_mapping_filename=ID_MAPPING_FILENAME):
     """
     The main control flow of the program that assembles reads.
@@ -215,9 +221,9 @@ def assemble(reads, output_directory, force, species_name=None, platform_name=No
         reads (Reads): the reads to assemble
         output_directory (string): the location to place all program output and temporary files
         force (bool): whether or not to force the assembly to continue, even when it's evaluated as being poor
+        mash_database_path (string): optional; the file path of the Mash database
         species_name (string): optional; the name of the species being assembled
         platform_name (string): optional; the name of the sequencing platform that generated the reads
-        mash_database_filename (string): optional; the name of the Mash database
         id_mapping_filename (string) optional; the name of the NCBI ID to taxonomy mapping database file
 
     POST:
@@ -252,7 +258,7 @@ def assemble(reads, output_directory, force, species_name=None, platform_name=No
     # Estimate species
     filtered_filenames = filtered_reads.get_file_locations()
     species_list = utilities.determine_species(filtered_filenames, assembly_database, output_directory,
-                                               mash_database_filename, id_mapping_filename, species_name)
+                                               mash_database_path, id_mapping_filename, species_name)
     species = species_list[0]
     report_species(species_list)
 
@@ -271,7 +277,7 @@ def assemble(reads, output_directory, force, species_name=None, platform_name=No
 
     # Check for contamination at the contig level:
     contamination_handler = ContaminationHandler(species, assembler.contigs_filename, output_directory,
-                                                 mash_database_filename, id_mapping_filename)
+                                                 mash_database_path, id_mapping_filename)
     evaluation = contamination_handler.estimate_contamination()
     report_contamination(evaluation)
 

--- a/proksee/commands/cmd_evaluate.py
+++ b/proksee/commands/cmd_evaluate.py
@@ -29,10 +29,10 @@ from proksee.assembly_measurer import AssemblyMeasurer
 from proksee.heuristic_evaluator import HeuristicEvaluator
 from proksee.machine_learning_evaluator import MachineLearningEvaluator
 
+import proksee.config as config
+
 DATABASE_PATH = os.path.join(Path(__file__).parent.parent.absolute(), "database",
                              "refseq_short.csv")
-MASH_DATABASE = os.path.join(Path(__file__).parent.parent.absolute(), "database",
-                             "refseq.genomes.k21s1000.msh")
 ID_MAPPING_FILENAME = os.path.join(Path(__file__).parent.parent.absolute(), "database",
                                    "mash_id_mapping.tab.gz")
 
@@ -50,24 +50,25 @@ ID_MAPPING_FILENAME = os.path.join(Path(__file__).parent.parent.absolute(), "dat
 def cli(ctx, contigs, output, species):
 
     # Check Mash database is installed:
-    if not os.path.isfile(MASH_DATABASE):
+    mash_database_path = config.get(config.MASH_PATH)
+
+    if not os.path.isfile(mash_database_path):
         print("Please run 'proksee updatedb' to install the databases!")
         return
 
-    evaluate(contigs, output, species)
+    evaluate(contigs, output, mash_database_path, species)
 
 
-def evaluate(contigs_filename, output_directory, species_name=None,
-             mash_database_filename=MASH_DATABASE,
-             id_mapping_filename=ID_MAPPING_FILENAME):
+def evaluate(contigs_filename, output_directory, mash_database_path,
+             species_name=None, id_mapping_filename=ID_MAPPING_FILENAME):
     """
     The main control flow of the program that evaluates the assembly.
 
     ARGUMENTS:
         contigs_filename (string): the filename of the contigs to evaluate
         output_directory (string): the location to place all program output and temporary files
+        mash_database_path (string): optional; the name of the Mash database
         species_name (string): optional; the name of the species being assembled
-        mash_database_filename (string): optional; the name of the Mash database
         id_mapping_filename (string) optional; the name of the NCBI ID-to-taxonomy mapping (table) file
 
     POST:
@@ -85,7 +86,7 @@ def evaluate(contigs_filename, output_directory, species_name=None,
 
     # Estimate species
     species_list = utilities.determine_species([contigs_filename], assembly_database, output_directory,
-                                               mash_database_filename, id_mapping_filename, species_name)
+                                               mash_database_path, id_mapping_filename, species_name)
     species = species_list[0]
     click.echo("The identified species is: " + str(species.name) + "\n")
 

--- a/proksee/commands/cmd_updatedb.py
+++ b/proksee/commands/cmd_updatedb.py
@@ -70,18 +70,19 @@ def update(directory):
                            "file from {} before timeout.".format(MASH_DATABASE_URL))
 
     # Make database directory:
+    directory = os.path.abspath(directory)
     if not os.path.isdir(directory):
         os.mkdir(directory)
 
-    config.update(config.DATABASE_DIRECTORY, directory)
-    mash_database_filename = os.path.join(directory, MASH_DATABASE_FILENAME)
+    mash_database_path = os.path.join(directory, MASH_DATABASE_FILENAME)
+    config.update(config.MASH_PATH, mash_database_path)
 
-    if not os.path.isfile(mash_database_filename) or \
-            file_size != os.path.getsize(mash_database_filename):
+    if not os.path.isfile(mash_database_path) or \
+            file_size != os.path.getsize(mash_database_path):
 
         click.echo("Downloading database...")
 
-        command = "wget -O " + str(mash_database_filename) + " " + MASH_DATABASE_URL
+        command = "wget -O " + str(mash_database_path) + " " + MASH_DATABASE_URL
 
         try:
             subprocess.check_call(command, shell=True)

--- a/proksee/config.py
+++ b/proksee/config.py
@@ -40,7 +40,7 @@ def update(key, value):
     config[key] = value
 
     with open(CONFIG_FILENAME, 'w') as f:
-        json.dump(config, f)
+        json.dump(config, f, indent=4)
 
 
 def get(key):

--- a/proksee/config.py
+++ b/proksee/config.py
@@ -23,8 +23,8 @@ import json
 
 from pathlib import Path
 
-CONFIG_FILENAME = os.path.join(Path(__file__).parent.absolute(), "config.json")
-DATABASE_DIRECTORY = "databaseDirectory"
+CONFIG_FILENAME = os.path.join(Path(__file__).parent.parent.absolute(), "config.json")
+MASH_PATH = "mashPath"
 
 
 def update(key, value):
@@ -34,12 +34,12 @@ def update(key, value):
     POST: The config file will be updated, such that the passed 'value', will be assigned to 'key'.
     """
 
-    with open('config.json', 'r') as f:
+    with open(CONFIG_FILENAME, 'r') as f:
         config = json.load(f)
 
     config[key] = value
 
-    with open('config.json', 'w') as f:
+    with open(CONFIG_FILENAME, 'w') as f:
         json.dump(config, f)
 
 
@@ -51,7 +51,7 @@ def get(key):
         value (string): the value stored in the config file for 'key'
     """
 
-    with open('config.json', 'r') as f:
+    with open(CONFIG_FILENAME, 'r') as f:
         config = json.load(f)
 
     value = config[key]

--- a/proksee/config.py
+++ b/proksee/config.py
@@ -1,0 +1,59 @@
+"""
+Copyright Government of Canada 2021
+
+Written by:
+
+Eric Marinier
+    National Microbiology Laboratory, Public Health Agency of Canada
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this work except in compliance with the License. You may obtain a copy of the
+License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import os
+import json
+
+from pathlib import Path
+
+CONFIG_FILENAME = os.path.join(Path(__file__).parent.absolute(), "config.json")
+DATABASE_DIRECTORY = "databaseDirectory"
+
+
+def update(key, value):
+    """
+    Updates the Proksee config file with the passed (key, value).
+
+    POST: The config file will be updated, such that the passed 'value', will be assigned to 'key'.
+    """
+
+    with open('config.json', 'r') as f:
+        config = json.load(f)
+
+    config[key] = value
+
+    with open('config.json', 'w') as f:
+        json.dump(config, f)
+
+
+def get(key):
+    """
+    Gets the value stored in the config file for 'key'.
+
+    RETURNS
+        value (string): the value stored in the config file for 'key'
+    """
+
+    with open('config.json', 'r') as f:
+        config = json.load(f)
+
+    value = config[key]
+
+    return value

--- a/tests/test_cmd_assemble.py
+++ b/tests/test_cmd_assemble.py
@@ -64,8 +64,9 @@ class TestCmdAssemble:
         if os.path.isfile(json_file):
             os.remove(json_file)
 
-        assemble(reads, OUTPUT_DIR, force, species_name=None, platform_name=None,
-                 mash_database_filename=TEST_MASH_DB_FILENAME,
+        assemble(reads, OUTPUT_DIR, force,
+                 TEST_MASH_DB_FILENAME,
+                 species_name=None, platform_name=None,
                  id_mapping_filename=TEST_ID_MAPPING_FILENAME)
 
         # Check that expected files were created:

--- a/tests/test_cmd_evaluate.py
+++ b/tests/test_cmd_evaluate.py
@@ -21,6 +21,7 @@ import os
 from pathlib import Path
 
 from proksee.commands.cmd_evaluate import evaluate
+import proksee.config as config
 
 INPUT_DIR = os.path.join(Path(__file__).parent.absolute(), "data")
 OUTPUT_DIR = os.path.join(Path(__file__).parent.absolute(), "output")
@@ -45,7 +46,8 @@ class TestCmdEvaluate:
         if os.path.isfile(quast_file):
             os.remove(quast_file)
 
-        evaluate(contigs_filename, OUTPUT_DIR, species_name=None)
+        mash_database_path = config.get(config.MASH_PATH)
+        evaluate(contigs_filename, OUTPUT_DIR, mash_database_path, species_name=None)
 
         # Check that expected files were created:
         assert os.path.isfile(quast_file)


### PR DESCRIPTION
The default proksee-cmd update Mash database behaviour (previously) was as follows:

`proksee assemble -o output reads.fastq`
> Please run 'proksee updatedb' to install the databases!

`proksee updatedb`
(The Mash database was downloaded into the proksee-cmd install directory.)

The new behaviour is as follows:

`proksee assemble -o output reads.fastq`
> Please run 'proksee updatedb' to install the databases!

`proksee updatedb -d databases`
(The Mash database will be downloaded to the specified directory, and a config.json file will be updated with the database location.)

If the Mash database location is not specified, the program behaviour will default the database location to the proksee-cmd install directory.