### PR TITLE
Clean up temporary files created during assembly.

### DIFF
--- a/proksee/assembly_measurer.py
+++ b/proksee/assembly_measurer.py
@@ -33,6 +33,9 @@ class AssemblyMeasurer:
         quast_report_filename (str): the filename of the quast report
     """
 
+    OUTPUT_FILENAME = "quast.out"
+    ERROR_FILENAME = "quast.err"
+
     def __init__(self, contigs_filename, output_directory):
         """
         Initializes the AssemblyEvaluator.
@@ -74,8 +77,8 @@ class AssemblyMeasurer:
             raise FileNotFoundError("File not found: " + self.contigs_filename)
 
         quast_command = "quast " + self.contigs_filename + " -o " + self.quast_directory
-        quast_out = open(os.path.join(self.output_directory, "quast.out"), "w+")
-        quast_err = open(os.path.join(self.output_directory, "quast.err"), "w+")
+        quast_out = open(os.path.join(self.output_directory, self.OUTPUT_FILENAME), "w+")
+        quast_err = open(os.path.join(self.output_directory, self.ERROR_FILENAME), "w+")
 
         try:
             subprocess.check_call(quast_command, shell=True, stdout=quast_out, stderr=quast_err)

--- a/proksee/commands/cmd_assemble.py
+++ b/proksee/commands/cmd_assemble.py
@@ -244,6 +244,15 @@ def cleanup(output_directory):
     if os.path.isfile(species_estimation_path):
         os.remove(species_estimation_path)
 
+    assembly_measurer_output_path = os.path.join(output_directory, AssemblyMeasurer.OUTPUT_FILENAME)
+    assembly_measurer_error_path = os.path.join(output_directory, AssemblyMeasurer.ERROR_FILENAME)
+
+    if os.path.isfile(assembly_measurer_output_path):
+        os.remove(assembly_measurer_error_path)
+
+    if os.path.isfile(assembly_measurer_output_path):
+        os.remove(assembly_measurer_error_path)
+
 
 def assemble(reads, output_directory, force, mash_database_path,
              species_name=None, platform_name=None,

--- a/proksee/commands/cmd_assemble.py
+++ b/proksee/commands/cmd_assemble.py
@@ -41,6 +41,7 @@ from proksee.read_filterer import ReadFilterer
 from proksee.expert_system import ExpertSystem
 from proksee.writer.assembly_statistics_writer import AssemblyStatisticsWriter
 from proksee import config as config
+from proksee.species_estimator import SpeciesEstimator
 
 DATABASE_PATH = os.path.join(Path(__file__).parent.parent.absolute(), "database",
                              "refseq_short.csv")
@@ -229,14 +230,19 @@ def cleanup(output_directory):
     if os.path.isfile(filterer_logfile_path):
         os.remove(filterer_logfile_path)
 
-    fwd_filtered_filename = os.path.join(output_directory, ReadFilterer.FWD_FILTERED_FILENAME)
-    rev_filtered_filename = os.path.join(output_directory, ReadFilterer.REV_FILTERED_FILENAME)
+    fwd_filtered_path = os.path.join(output_directory, ReadFilterer.FWD_FILTERED_FILENAME)
+    rev_filtered_path = os.path.join(output_directory, ReadFilterer.REV_FILTERED_FILENAME)
 
-    if os.path.isfile(fwd_filtered_filename):
-        os.remove(fwd_filtered_filename)
+    if os.path.isfile(fwd_filtered_path):
+        os.remove(fwd_filtered_path)
 
-    if os.path.isfile(rev_filtered_filename):
-        os.remove(rev_filtered_filename)
+    if os.path.isfile(rev_filtered_path):
+        os.remove(rev_filtered_path)
+
+    species_estimation_path = os.path.join(output_directory, SpeciesEstimator.OUTPUT_FILENAME)
+
+    if os.path.isfile(species_estimation_path):
+        os.remove(species_estimation_path)
 
 
 def assemble(reads, output_directory, force, mash_database_path,

--- a/proksee/commands/cmd_assemble.py
+++ b/proksee/commands/cmd_assemble.py
@@ -224,10 +224,19 @@ def cleanup(output_directory):
     if os.path.isdir(fasta_directory):
         rmtree(fasta_directory)
 
-    filterer_logfile_path = os.path.join(output_directory, ReadFilterer.LOGFILE_NAME)
+    filterer_logfile_path = os.path.join(output_directory, ReadFilterer.LOGFILE_FILENAME)
 
     if os.path.isfile(filterer_logfile_path):
         os.remove(filterer_logfile_path)
+
+    fwd_filtered_filename = os.path.join(output_directory, ReadFilterer.FWD_FILTERED_FILENAME)
+    rev_filtered_filename = os.path.join(output_directory, ReadFilterer.REV_FILTERED_FILENAME)
+
+    if os.path.isfile(fwd_filtered_filename):
+        os.remove(fwd_filtered_filename)
+
+    if os.path.isfile(rev_filtered_filename):
+        os.remove(rev_filtered_filename)
 
 
 def assemble(reads, output_directory, force, mash_database_path,

--- a/proksee/commands/cmd_assemble.py
+++ b/proksee/commands/cmd_assemble.py
@@ -26,6 +26,7 @@ import click
 import os
 
 from pathlib import Path
+from shutil import rmtree
 
 from proksee import utilities
 from proksee.assembly_database import AssemblyDatabase
@@ -204,6 +205,24 @@ def cli(ctx, forward, reverse, output, force, species, platform):
 
     reads = Reads(forward, reverse)
     assemble(reads, output, force, mash_database_path, species, platform)
+    cleanup(output)
+
+
+def cleanup(output_directory):
+    """
+    Cleans up temporary files in the output directory.
+
+    ARGUMENTS:
+        output_directory (string): the location of the program output
+
+    POST:
+        The output directory will have all temporary program files deleted.
+    """
+
+    fasta_directory = os.path.join(output_directory, ContaminationHandler.FASTA_DIRECTORY)
+
+    if os.path.isdir(fasta_directory):
+        rmtree(fasta_directory)
 
 
 def assemble(reads, output_directory, force, mash_database_path,

--- a/proksee/commands/cmd_assemble.py
+++ b/proksee/commands/cmd_assemble.py
@@ -250,13 +250,13 @@ def cleanup(output_directory):
     assembly_measurer_error_path = os.path.join(output_directory, AssemblyMeasurer.ERROR_FILENAME)
 
     if os.path.isfile(assembly_measurer_output_path):
+        os.remove(assembly_measurer_output_path)
+
+    if os.path.isfile(assembly_measurer_error_path):
         os.remove(assembly_measurer_error_path)
 
-    if os.path.isfile(assembly_measurer_output_path):
-        os.remove(assembly_measurer_error_path)
-
-    skesa_directory = os.path.isfile(SkesaAssembler.DIRECTORY_NAME)
-    spades_directory = os.path.isfile(SpadesAssembler.DIRECTORY_NAME)
+    skesa_directory = os.path.join(output_directory, SkesaAssembler.DIRECTORY_NAME)
+    spades_directory = os.path.join(output_directory, SpadesAssembler.DIRECTORY_NAME)
 
     if os.path.isdir(skesa_directory):
         rmtree(skesa_directory)

--- a/proksee/commands/cmd_assemble.py
+++ b/proksee/commands/cmd_assemble.py
@@ -224,6 +224,11 @@ def cleanup(output_directory):
     if os.path.isdir(fasta_directory):
         rmtree(fasta_directory)
 
+    filterer_logfile_path = os.path.join(output_directory, ReadFilterer.LOGFILE_NAME)
+
+    if os.path.isfile(filterer_logfile_path):
+        os.remove(filterer_logfile_path)
+
 
 def assemble(reads, output_directory, force, mash_database_path,
              species_name=None, platform_name=None,

--- a/proksee/commands/cmd_assemble.py
+++ b/proksee/commands/cmd_assemble.py
@@ -222,16 +222,19 @@ def cleanup(output_directory):
         The output directory will have all temporary program files deleted.
     """
 
+    # Temporary FASTA directory used in contamination detection:
     fasta_directory = os.path.join(output_directory, ContaminationHandler.FASTA_DIRECTORY)
 
     if os.path.isdir(fasta_directory):
         rmtree(fasta_directory)
 
+    # Read filtering logfile (i.e. fastp.log):
     filterer_logfile_path = os.path.join(output_directory, ReadFilterer.LOGFILE_FILENAME)
 
     if os.path.isfile(filterer_logfile_path):
         os.remove(filterer_logfile_path)
 
+    # Forward and reverse filtered read files:
     fwd_filtered_path = os.path.join(output_directory, ReadFilterer.FWD_FILTERED_FILENAME)
     rev_filtered_path = os.path.join(output_directory, ReadFilterer.REV_FILTERED_FILENAME)
 
@@ -241,11 +244,13 @@ def cleanup(output_directory):
     if os.path.isfile(rev_filtered_path):
         os.remove(rev_filtered_path)
 
+    # Species estimation output (i.e. mash.o):
     species_estimation_path = os.path.join(output_directory, SpeciesEstimator.OUTPUT_FILENAME)
 
     if os.path.isfile(species_estimation_path):
         os.remove(species_estimation_path)
 
+    # Assembly quality measurer temporary files (i.e. quast.out and quast.err)
     assembly_measurer_output_path = os.path.join(output_directory, AssemblyMeasurer.OUTPUT_FILENAME)
     assembly_measurer_error_path = os.path.join(output_directory, AssemblyMeasurer.ERROR_FILENAME)
 
@@ -255,6 +260,7 @@ def cleanup(output_directory):
     if os.path.isfile(assembly_measurer_error_path):
         os.remove(assembly_measurer_error_path)
 
+    # Assembly output directories:
     skesa_directory = os.path.join(output_directory, SkesaAssembler.DIRECTORY_NAME)
     spades_directory = os.path.join(output_directory, SpadesAssembler.DIRECTORY_NAME)
 

--- a/proksee/commands/cmd_assemble.py
+++ b/proksee/commands/cmd_assemble.py
@@ -42,6 +42,8 @@ from proksee.expert_system import ExpertSystem
 from proksee.writer.assembly_statistics_writer import AssemblyStatisticsWriter
 from proksee import config as config
 from proksee.species_estimator import SpeciesEstimator
+from proksee.skesa_assembler import SkesaAssembler
+from proksee.spades_assembler import SpadesAssembler
 
 DATABASE_PATH = os.path.join(Path(__file__).parent.parent.absolute(), "database",
                              "refseq_short.csv")
@@ -252,6 +254,15 @@ def cleanup(output_directory):
 
     if os.path.isfile(assembly_measurer_output_path):
         os.remove(assembly_measurer_error_path)
+
+    skesa_directory = os.path.isfile(SkesaAssembler.DIRECTORY_NAME)
+    spades_directory = os.path.isfile(SpadesAssembler.DIRECTORY_NAME)
+
+    if os.path.isdir(skesa_directory):
+        rmtree(skesa_directory)
+
+    if os.path.isdir(spades_directory):
+        rmtree(spades_directory)
 
 
 def assemble(reads, output_directory, force, mash_database_path,

--- a/proksee/contamination_handler.py
+++ b/proksee/contamination_handler.py
@@ -38,6 +38,8 @@ class ContaminationHandler:
         id_mapping_filename (str): filename of the NCBI ID-to-taxonomy mapping file
     """
 
+    FASTA_DIRECTORY = "fasta"
+
     def __init__(self, species, contigs_file, output_directory, mash_database_filename, id_mapping_filename):
         """
         Initializes the contamination handler.
@@ -66,10 +68,9 @@ class ContaminationHandler:
                 contains an associated, plain-language report
         """
 
-        FASTA_DIRECTORY = "fasta"
         CHUNKS = 5
 
-        fasta_directory = os.path.join(self.output_directory, FASTA_DIRECTORY)
+        fasta_directory = os.path.join(self.output_directory, self.FASTA_DIRECTORY)
 
         # Split the multi-FASTA file into single-record FASTA files (contigs) and gather a list of file locations in
         # descending order by contig size:

--- a/proksee/read_filterer.py
+++ b/proksee/read_filterer.py
@@ -35,7 +35,9 @@ class ReadFilterer():
         output_directory (str): the file location of the output directory for writing files
     """
 
-    LOGFILE_NAME = "fastp.log"
+    LOGFILE_FILENAME = "fastp.log"
+    FWD_FILTERED_FILENAME = "fwd_filtered.fastq"
+    REV_FILTERED_FILENAME = "rev_filtered.fastq"
 
     def __init__(self, reads, output_directory):
         """
@@ -60,8 +62,9 @@ class ReadFilterer():
         forward_reads = self.reads.forward
         reverse_reads = self.reads.reverse
 
-        self.forward_filtered = os.path.join(self.output_directory, 'fwd_filtered.fastq')
-        self.reverse_filtered = os.path.join(self.output_directory, 'rev_filtered.fastq') if reverse_reads else None
+        self.forward_filtered = os.path.join(self.output_directory, self.FWD_FILTERED_FILENAME)
+        self.reverse_filtered = os.path.join(self.output_directory,
+                                             self.REV_FILTERED_FILENAME) if reverse_reads else None
         json = os.path.join(self.output_directory, 'fastp.json')
         html = os.path.join(self.output_directory, 'fastp.html')
 
@@ -80,7 +83,7 @@ class ReadFilterer():
         Runs the FASTP program in order to perform filtering on reads.
         """
 
-        logfile_location = open(os.path.join(self.output_directory, self.LOGFILE_NAME), 'w+')
+        logfile_location = open(os.path.join(self.output_directory, self.LOGFILE_FILENAME), 'w+')
         command = self.__build_fastp_command()
 
         try:

--- a/proksee/read_filterer.py
+++ b/proksee/read_filterer.py
@@ -35,6 +35,8 @@ class ReadFilterer():
         output_directory (str): the file location of the output directory for writing files
     """
 
+    LOGFILE_NAME = "fastp.log"
+
     def __init__(self, reads, output_directory):
         """
         Initializes the read filterer.
@@ -78,7 +80,7 @@ class ReadFilterer():
         Runs the FASTP program in order to perform filtering on reads.
         """
 
-        logfile_location = open(os.path.join(self.output_directory, 'fastp.log'), 'w+')
+        logfile_location = open(os.path.join(self.output_directory, self.LOGFILE_NAME), 'w+')
         command = self.__build_fastp_command()
 
         try:

--- a/proksee/species_estimator.py
+++ b/proksee/species_estimator.py
@@ -79,6 +79,8 @@ class SpeciesEstimator:
         id_mapping_filename (str): filename of the NCBI ID-to-taxonomy mapping file
     """
 
+    OUTPUT_FILENAME = "mash.o"
+
     def __init__(self, input_list, output_directory, mash_database_filename, id_mapping_filename):
         """
         Initializes the species estimator.
@@ -157,7 +159,7 @@ class SpeciesEstimator:
             will be written to file.
         """
 
-        OUTPUT_FILENAME = os.path.join(self.output_directory, "mash.o")
+        output_filepath = os.path.join(self.output_directory, self.OUTPUT_FILENAME)
 
         # create the mash command
         command = "mash screen -i 0 -v 1 " + self.mash_database_filename
@@ -165,7 +167,7 @@ class SpeciesEstimator:
         for item in self.input_list:
             command += " " + str(item)
 
-        command += " | sort -gr > " + OUTPUT_FILENAME
+        command += " | sort -gr > " + output_filepath
 
         # run mash
         try:
@@ -174,4 +176,4 @@ class SpeciesEstimator:
         except subprocess.CalledProcessError:
             pass  # it will be the responsibility of the calling function to insure there was output
 
-        return OUTPUT_FILENAME
+        return output_filepath


### PR DESCRIPTION
Cleans up temporary files after assembly. Leaves only the following:

- assembly_info.json
- assembly_statistics.csv
- contigs.fasta (largest file, unsurprisingly)
- fastp.html
- fastp.json
- quast (directory, approx 1.4 Mb)