### PR TITLE
Adding Read File Locations to JSON Output

### DIFF
--- a/proksee/commands/cmd_assemble.py
+++ b/proksee/commands/cmd_assemble.py
@@ -387,8 +387,8 @@ def assemble(reads, output_directory, force, mash_database_path,
     assembly_statistics_writer.write_csv([fast_strategy.assembler.name, expert_strategy.assembler.name],
                                          [fast_assembly_quality, expert_assembly_quality])
 
-    # Write expert assembly information to JSON file:
-    assembly_statistics_writer.write_json(platform, species, read_quality, expert_assembly_quality,
+    # Write assembly information to JSON file:
+    assembly_statistics_writer.write_json(platform, species, reads, read_quality, expert_assembly_quality,
                                           heuristic_evaluation, machine_learning_evaluation)
 
     # Move final assembled contigs to the main level of the output directory and rename it.

--- a/proksee/writer/assembly_statistics_writer.py
+++ b/proksee/writer/assembly_statistics_writer.py
@@ -90,7 +90,7 @@ class AssemblyStatisticsWriter:
 
             return output_filename
 
-    def write_json(self, platform, species, read_quality, assembly_quality,
+    def write_json(self, platform, species, reads, read_quality, assembly_quality,
                    heuristic_evaluation, machine_learning_evaluation):
         """
         Writes the assembly information to a JSON file.
@@ -98,6 +98,7 @@ class AssemblyStatisticsWriter:
         PARAMETERS
             platform (Platform (Enum)): the sequencing platform
             species (Species): the sequencing species
+            reads (Reads): encapsulates the file names of the input reads
             read_quality (ReadQuality): object encapsulating the quality measurements of the sequencing reads
             assembly_quality (AssemblyQuality): object encapsulating the quality measurements of the assembly
             heuristic_evaluation (AssemblyEvaluation): heuristic evaluation of the assembly
@@ -122,6 +123,11 @@ class AssemblyStatisticsWriter:
 
         data['Technology'] = str(platform.value)
         data['Species'] = species.name
+
+        data["Reads"] = {
+            "Forward": reads.forward,
+            "Reverse": reads.reverse
+        }
 
         data['Read Quality'] = {
             "Total Reads": read_quality.total_reads,

--- a/tests/test_assembly_statistics_writer.py
+++ b/tests/test_assembly_statistics_writer.py
@@ -27,6 +27,7 @@ from proksee.assembly_quality import AssemblyQuality
 from proksee.evaluation import AssemblyEvaluation, Evaluation, MachineLearningEvaluation
 from proksee.platform_identify import Platform
 from proksee.read_quality import ReadQuality
+from proksee.reads import Reads
 from proksee.species import Species
 from proksee.writer.assembly_statistics_writer import AssemblyStatisticsWriter
 
@@ -75,6 +76,7 @@ class TestAssemblyStatisticsWriter:
 
         platform = Platform.ILLUMINA
         species = Species("Listeria monocytogenes", 1.0)
+        reads = Reads("forward.fastq", "reverse.fastq")
 
         # num_contigs, n50, n75, l50, l75, gc_content, length
         assembly_quality = AssemblyQuality(10, 9000, 5000, 5, 3, 0.51, 25000)
@@ -106,7 +108,7 @@ class TestAssemblyStatisticsWriter:
             True
         )
 
-        json_file_location = writer.write_json(platform, species, read_quality, assembly_quality,
+        json_file_location = writer.write_json(platform, species, reads, read_quality, assembly_quality,
                                                heuristic_evaluation, machine_learning_evaluation)
 
         with open(json_file_location) as json_file:


### PR DESCRIPTION
Specifies the input read file locations in the JSON output.

Example:

```
    "Reads": {
        "Forward": "/home/eric/Downloads/SRR17792936_1.fastq",
        "Reverse": "/home/eric/Downloads/SRR17792936_2.fastq"
    },
```