### PR TITLE
Adds Basic Resource Specification

### DIFF
--- a/docs/tools/assemble.md
+++ b/docs/tools/assemble.md
@@ -70,6 +70,22 @@ This option allows the user to specify the species in the reads to be assembled.
 
 The option allows the user to specify the sequencing platform that generated the reads. The name must be either: 'Illumina', 'Pac Bio', or 'Ion Torrent'. For example: `--platform 'Ion Torrent'`. If the passed platform name does not match a known platform, then the pipeline will attempt to identify the platform from the reads as normal.
 
+### Threads
+
+```bash
+-t , --threads
+```
+
+The option allows the user to specify the number of threads that the sequence assembly programs should use.
+
+### Memory
+
+```bash
+-m , --memory
+```
+
+The option allows the user to specify the amount of memory in gigabytes that the sequence assembly programs should use.
+
 ### Help
 
 ```bash

--- a/docs/tutorials/assemble.md
+++ b/docs/tutorials/assemble.md
@@ -49,13 +49,14 @@ Options:
   -o, --output DIRECTORY  [required]
   --force                 This will force the assembler to proceed when the
                           assembly appears to be poor.
-
   -s, --species TEXT      The species to assemble. This will override species
                           estimation. Must be spelled correctly.
-
   -p, --platform TEXT     The sequencing platform used to generate the reads.
                           'Illumina', 'Ion Torrent', or 'Pac Bio'.
-
+  -t, --threads INTEGER   Specifies the number of threads programs in the
+                          pipeline should use. The default is 4.
+  -m, --memory INTEGER    Specifies the amount of memory in gigabytes programs
+                          in the pipeline should use. The default is 4
   --help                  Show this message and exit.
 ```
 

--- a/proksee/assembler.py
+++ b/proksee/assembler.py
@@ -34,7 +34,7 @@ class Assembler(ABC):
         name (str): the plain-language name of the assembler
         reads (Reads): the reads to assemble
         output_dir (str): the filename of the output directory
-        resource_specification (ResourceSpecification): the specification of resource that the assembler should use
+        resource_specification (ResourceSpecification): the resources that the assembler should use
     """
 
     def __init__(self, name, reads, output_dir, resource_specification):
@@ -45,7 +45,7 @@ class Assembler(ABC):
             name (str): the plain-language name of the assembler
             reads (Reads): the reads to assemble
             output_dir (str): the filename of the output directory
-            resource_specification (ResourceSpecification): the specification of resource that the assembler should use
+            resource_specification (ResourceSpecification): the resources that the assembler should use
         """
 
         if not os.path.isfile(reads.forward):

--- a/proksee/assembler.py
+++ b/proksee/assembler.py
@@ -34,9 +34,10 @@ class Assembler(ABC):
         name (str): the plain-language name of the assembler
         reads (Reads): the reads to assemble
         output_dir (str): the filename of the output directory
+        resource_specification (ResourceSpecification): the specification of resource that the assembler should use
     """
 
-    def __init__(self, name, reads, output_dir):
+    def __init__(self, name, reads, output_dir, resource_specification):
         """
         Initializes the abstract assembler.
 
@@ -44,6 +45,7 @@ class Assembler(ABC):
             name (str): the plain-language name of the assembler
             reads (Reads): the reads to assemble
             output_dir (str): the filename of the output directory
+            resource_specification (ResourceSpecification): the specification of resource that the assembler should use
         """
 
         if not os.path.isfile(reads.forward):
@@ -52,6 +54,7 @@ class Assembler(ABC):
         self.name = name
         self.reads = reads
         self.output_dir = output_dir
+        self.resource_specification = resource_specification
 
     @abstractmethod
     def assemble(self):

--- a/proksee/commands/cmd_assemble.py
+++ b/proksee/commands/cmd_assemble.py
@@ -44,6 +44,7 @@ from proksee import config as config
 from proksee.species_estimator import SpeciesEstimator
 from proksee.skesa_assembler import SkesaAssembler
 from proksee.spades_assembler import SpadesAssembler
+from proksee.resource_specification import ResourceSpecification
 
 DATABASE_PATH = os.path.join(Path(__file__).parent.parent.absolute(), "database",
                              "refseq_short.csv")
@@ -196,8 +197,12 @@ def determine_platform(reads, platform_name=None):
               help="The species to assemble. This will override species estimation. Must be spelled correctly.")
 @click.option('-p', '--platform', required=False, default=None,
               help="The sequencing platform used to generate the reads. 'Illumina', 'Ion Torrent', or 'Pac Bio'.")
+@click.option('-t', '--threads', required=False, default=4,
+              help="Specifies the number of threads programs in the pipeline should use. The default is 4.")
+@click.option('-m', '--memory', required=False, default=4,
+              help="Specifies the amount of memory in gigabytes programs in the pipeline should use. The default is 4")
 @click.pass_context
-def cli(ctx, forward, reverse, output, force, species, platform):
+def cli(ctx, forward, reverse, output, force, species, platform, threads, memory):
 
     # Check Mash database is installed:
     mash_database_path = config.get(config.MASH_PATH)
@@ -207,7 +212,8 @@ def cli(ctx, forward, reverse, output, force, species, platform):
         return
 
     reads = Reads(forward, reverse)
-    assemble(reads, output, force, mash_database_path, species, platform)
+    resource_specification = ResourceSpecification(threads, memory)
+    assemble(reads, output, force, mash_database_path, resource_specification, species, platform)
     cleanup(output)
 
 
@@ -271,7 +277,7 @@ def cleanup(output_directory):
         rmtree(spades_directory)
 
 
-def assemble(reads, output_directory, force, mash_database_path,
+def assemble(reads, output_directory, force, mash_database_path, resource_specification,
              species_name=None, platform_name=None,
              id_mapping_filename=ID_MAPPING_FILENAME):
     """
@@ -282,6 +288,7 @@ def assemble(reads, output_directory, force, mash_database_path,
         output_directory (string): the location to place all program output and temporary files
         force (bool): whether or not to force the assembly to continue, even when it's evaluated as being poor
         mash_database_path (string): optional; the file path of the Mash database
+        resource_specification (ResourceSpecification): the specification of resource that sub-programs should use
         species_name (string): optional; the name of the species being assembled
         platform_name (string): optional; the name of the sequencing platform that generated the reads
         id_mapping_filename (string) optional; the name of the NCBI ID to taxonomy mapping database file
@@ -323,7 +330,7 @@ def assemble(reads, output_directory, force, mash_database_path,
     report_species(species_list)
 
     # Determine a fast assembly strategy:
-    expert = ExpertSystem(platform, species, filtered_reads, output_directory)
+    expert = ExpertSystem(platform, species, filtered_reads, output_directory, resource_specification)
     fast_strategy = expert.create_fast_assembly_strategy(read_quality)
     report_strategy(fast_strategy)
 

--- a/proksee/commands/cmd_assemble.py
+++ b/proksee/commands/cmd_assemble.py
@@ -288,7 +288,7 @@ def assemble(reads, output_directory, force, mash_database_path, resource_specif
         output_directory (string): the location to place all program output and temporary files
         force (bool): whether or not to force the assembly to continue, even when it's evaluated as being poor
         mash_database_path (string): optional; the file path of the Mash database
-        resource_specification (ResourceSpecification): the specification of resource that sub-programs should use
+        resource_specification (ResourceSpecification): the resources that sub-programs should use
         species_name (string): optional; the name of the species being assembled
         platform_name (string): optional; the name of the sequencing platform that generated the reads
         id_mapping_filename (string) optional; the name of the NCBI ID to taxonomy mapping database file

--- a/proksee/expert_system.py
+++ b/proksee/expert_system.py
@@ -34,7 +34,7 @@ class ExpertSystem:
         species (species): the species to be assembled
         reads (Reads): the reads to assemble
         output_directory (str): the directory to use for program output
-        resource_specification (ResourceSpecification): the specification of resource that sub-programs should use
+        resource_specification (ResourceSpecification): the resources that sub-programs should use
     """
 
     def __init__(self, platform, species, reads, output_directory, resource_specification):
@@ -46,7 +46,7 @@ class ExpertSystem:
             species (species): the species to assemble
             reads (Reads): the reads to assemble
             output_directory (str): the directory to use for program output
-            resource_specification (ResourceSpecification): the specification of resource that sub-programs should use
+            resource_specification (ResourceSpecification): the resources that sub-programs should use
         """
 
         self.platform = platform

--- a/proksee/expert_system.py
+++ b/proksee/expert_system.py
@@ -34,9 +34,10 @@ class ExpertSystem:
         species (species): the species to be assembled
         reads (Reads): the reads to assemble
         output_directory (str): the directory to use for program output
+        resource_specification (ResourceSpecification): the specification of resource that sub-programs should use
     """
 
-    def __init__(self, platform, species, reads, output_directory):
+    def __init__(self, platform, species, reads, output_directory, resource_specification):
         """
         Initializes the expert system.
 
@@ -45,12 +46,14 @@ class ExpertSystem:
             species (species): the species to assemble
             reads (Reads): the reads to assemble
             output_directory (str): the directory to use for program output
+            resource_specification (ResourceSpecification): the specification of resource that sub-programs should use
         """
 
         self.platform = platform
         self.species = species
         self.reads = reads
         self.output_directory = output_directory
+        self.resource_specification = resource_specification
 
         return
 
@@ -77,7 +80,7 @@ class ExpertSystem:
         else:
             report += "The read quality is acceptable.\n"
 
-        assembler = SkesaAssembler(self.reads, self.output_directory)
+        assembler = SkesaAssembler(self.reads, self.output_directory, self.resource_specification)
 
         return AssemblyStrategy(proceed, assembler, report)
 
@@ -101,7 +104,7 @@ class ExpertSystem:
             evaluator = HeuristicEvaluator(self.species, assembly_database)
             evaluation = evaluator.evaluate(assembly_quality)
 
-            assembler = SpadesAssembler(self.reads, self.output_directory)
+            assembler = SpadesAssembler(self.reads, self.output_directory, self.resource_specification)
             proceed = evaluation.success  # proceed if evaluation was successful
             strategy = AssemblyStrategy(proceed, assembler, evaluation.report)
 
@@ -127,7 +130,7 @@ class ExpertSystem:
         evaluator = HeuristicEvaluator(self.species, assembly_database)
         evaluation = evaluator.evaluate(assembly_quality)
 
-        assembler = SpadesAssembler(self.reads, self.output_directory)
+        assembler = SpadesAssembler(self.reads, self.output_directory, self.resource_specification)
         proceed = evaluation.success  # proceed if evaluation was successful
         strategy = AssemblyStrategy(proceed, assembler, evaluation.report)
 

--- a/proksee/resource_specification.py
+++ b/proksee/resource_specification.py
@@ -1,0 +1,42 @@
+"""
+Copyright Government of Canada 2022
+
+Written by:
+
+Eric Marinier
+    National Microbiology Laboratory, Public Health Agency of Canada
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this work except in compliance with the License. You may obtain a copy of the
+License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+
+class ResourceSpecification:
+    """
+    A class representing the resource specifications that sub-programs in the Proksee pipeline should adhere to
+    (ex:memory, threads).
+
+    ATTRIBUTES
+        threads (int): the number of threads to use
+        memory (int): the amount of memory in gigabytes to use
+    """
+
+    def __init__(self, threads, memory):
+        """
+        Initializes the resource specification.
+
+        PARAMETERS
+            threads (int): the number of threads to use
+            memory (int): the amount of memory in gigabytes to use
+        """
+
+        self.threads = threads
+        self.memory = memory

--- a/proksee/skesa_assembler.py
+++ b/proksee/skesa_assembler.py
@@ -39,19 +39,20 @@ class SkesaAssembler(Assembler):
 
     DIRECTORY_NAME = "skesa"
 
-    def __init__(self, reads, output_dir):
+    def __init__(self, reads, output_dir, resource_specification):
         """
         Initializes the Skesa assembler.
 
         PARAMETERS
             reads (Reads): the reads to assemble
             output_dir (str): the filename of the output directory
+            resource_specification (ResourceSpecification): the specification of resource that the assembler should use
         """
 
         NAME = "Skesa"
 
         skesa_directory = os.path.join(output_dir, self.DIRECTORY_NAME)
-        super().__init__(NAME, reads, skesa_directory)
+        super().__init__(NAME, reads, skesa_directory, resource_specification)
 
         self.contigs_filename = os.path.join(skesa_directory, 'contigs.fasta')
         self.log_filename = os.path.join(skesa_directory, 'skesa.log')
@@ -64,11 +65,18 @@ class SkesaAssembler(Assembler):
             command (str): the command for running Skesa on the command line
         """
 
+        # (below we assumes cores = threads)
+
         if self.reads.reverse is None:
-            command = 'skesa --fastq ' + self.reads.forward
+            command = "skesa --fastq " + self.reads.forward + \
+                      " --cores " + str(self.resource_specification.threads) + \
+                      " --memory " + str(self.resource_specification.memory)
 
         else:
-            command = 'skesa --fastq ' + self.reads.forward + ',' + self.reads.reverse
+            command = "skesa --fastq " + self.reads.forward + \
+                      "," + self.reads.reverse + \
+                      " --cores " + str(self.resource_specification.threads) + \
+                      " --memory " + str(self.resource_specification.memory)
 
         return command
 

--- a/proksee/skesa_assembler.py
+++ b/proksee/skesa_assembler.py
@@ -46,7 +46,7 @@ class SkesaAssembler(Assembler):
         PARAMETERS
             reads (Reads): the reads to assemble
             output_dir (str): the filename of the output directory
-            resource_specification (ResourceSpecification): the specification of resource that the assembler should use
+            resource_specification (ResourceSpecification): the resources that the assembler should use
         """
 
         NAME = "Skesa"

--- a/proksee/spades_assembler.py
+++ b/proksee/spades_assembler.py
@@ -35,19 +35,20 @@ class SpadesAssembler(Assembler):
 
     DIRECTORY_NAME = "spades"
 
-    def __init__(self, reads, output_dir):
+    def __init__(self, reads, output_dir, resource_specification):
         """
         Initializes the SPAdes assembler.
 
         PARAMETERS
             reads (Reads): the reads to assemble
             output_dir (str): the filename of the output directory
+            resource_specification (ResourceSpecification): the specification of resource that the assembler should use
         """
 
         NAME = "SPAdes"
 
         spades_directory = os.path.join(output_dir, self.DIRECTORY_NAME)
-        super().__init__(NAME, reads, spades_directory)
+        super().__init__(NAME, reads, spades_directory, resource_specification)
 
         self.contigs_filename = os.path.join(spades_directory, "contigs.fasta")
 
@@ -69,10 +70,16 @@ class SpadesAssembler(Assembler):
         error = open(error_filename, 'w+')
 
         if self.reads.reverse is None:
-            command = "spades.py -s " + str(self.reads.forward) + " -o " + str(self.output_dir)
+            command = "spades.py -s " + str(self.reads.forward) + \
+                      " -o " + str(self.output_dir) + \
+                      " -t " + str(self.resource_specification.threads) + \
+                      " -m " + str(self.resource_specification.memory)
         else:
-            command = "spades.py -1 " + str(self.reads.forward) + " -2 " + str(self.reads.reverse) + " -o " + \
-                      str(self.output_dir)
+            command = "spades.py -1 " + str(self.reads.forward) + \
+                      " -2 " + str(self.reads.reverse) + \
+                      " -o " + str(self.output_dir) + \
+                      " -t " + str(self.resource_specification.threads) + \
+                      " -m " + str(self.resource_specification.memory)
 
         try:
             subprocess.check_call(command, shell=True, stdout=output, stderr=error)

--- a/proksee/spades_assembler.py
+++ b/proksee/spades_assembler.py
@@ -42,7 +42,7 @@ class SpadesAssembler(Assembler):
         PARAMETERS
             reads (Reads): the reads to assemble
             output_dir (str): the filename of the output directory
-            resource_specification (ResourceSpecification): the specification of resource that the assembler should use
+            resource_specification (ResourceSpecification): the resources that the assembler should use
         """
 
         NAME = "SPAdes"

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -22,9 +22,11 @@ from pathlib import Path
 from proksee.assembler import Assembler
 from proksee.reads import Reads
 from proksee.skesa_assembler import SkesaAssembler
+from proksee.resource_specification import ResourceSpecification
 
 INPUT_DIR = os.path.join(Path(__file__).parent.absolute(), "data")
 OUTPUT_DIR = os.path.join(Path(__file__).parent.absolute(), "output")
+RESOURCE_SPECIFICATION = ResourceSpecification(4, 4)  # 4 threads, 4 gigabytes
 
 
 class TestAssembler:
@@ -40,7 +42,7 @@ class TestAssembler:
         reads = Reads(forward_filename, reverse_filename)
 
         # Can't instantiate abstract class, need to instantiate subclass:
-        assembler = SkesaAssembler(reads, OUTPUT_DIR)
+        assembler = SkesaAssembler(reads, OUTPUT_DIR, RESOURCE_SPECIFICATION)
 
         Assembler.assemble(assembler)
         Assembler.get_contigs_filename(assembler)

--- a/tests/test_cmd_assemble.py
+++ b/tests/test_cmd_assemble.py
@@ -22,9 +22,11 @@ from pathlib import Path
 
 from proksee.reads import Reads
 from proksee.commands.cmd_assemble import assemble
+from proksee.resource_specification import ResourceSpecification
 
 INPUT_DIR = os.path.join(Path(__file__).parent.absolute(), "data")
 OUTPUT_DIR = os.path.join(Path(__file__).parent.absolute(), "output")
+RESOURCE_SPECIFICATION = ResourceSpecification(4, 4)  # 4 threads, 4 gigabytes
 
 TEST_MASH_DB_FILENAME = os.path.join(Path(__file__).parent.absolute(), "data", "ecoli.msh")
 TEST_ID_MAPPING_FILENAME = os.path.join(Path(__file__).parent.absolute(), "data", "test_id_mapping.tab")
@@ -65,7 +67,7 @@ class TestCmdAssemble:
             os.remove(json_file)
 
         assemble(reads, OUTPUT_DIR, force,
-                 TEST_MASH_DB_FILENAME,
+                 TEST_MASH_DB_FILENAME, RESOURCE_SPECIFICATION,
                  species_name=None, platform_name=None,
                  id_mapping_filename=TEST_ID_MAPPING_FILENAME)
 

--- a/tests/test_expert_system.py
+++ b/tests/test_expert_system.py
@@ -25,9 +25,11 @@ from proksee.parser.assembly_quality_parser import parse_assembly_quality_from_q
 from proksee.parser.read_quality_parser import parse_read_quality_from_fastp
 from proksee.reads import Reads
 from proksee.species import Species
+from proksee.resource_specification import ResourceSpecification
 
 INPUT_DIR = os.path.join(Path(__file__).parent.absolute(), "data")
 OUTPUT_DIR = TEST_INPUT_DIR = os.path.join(Path(__file__).parent.absolute(), "output")
+RESOURCE_SPECIFICATION = ResourceSpecification(4, 4)  # 4 threads, 4 gigabytes
 
 
 class TestExpertSystem:
@@ -44,7 +46,7 @@ class TestExpertSystem:
         reads = Reads(forward, reverse)
         FASTP_PATH = os.path.join(Path(__file__).parent.parent.absolute(), "tests", "data", "good_reads.json")
 
-        system = ExpertSystem(platform, species, reads, OUTPUT_DIR)
+        system = ExpertSystem(platform, species, reads, OUTPUT_DIR, RESOURCE_SPECIFICATION)
         read_quality = parse_read_quality_from_fastp(FASTP_PATH)
 
         strategy = system.create_fast_assembly_strategy(read_quality)
@@ -63,7 +65,7 @@ class TestExpertSystem:
         reads = Reads(forward, reverse)
         FASTP_PATH = os.path.join(Path(__file__).parent.parent.absolute(), "tests", "data", "bad_reads.json")
 
-        system = ExpertSystem(platform, species, reads, OUTPUT_DIR)
+        system = ExpertSystem(platform, species, reads, OUTPUT_DIR, RESOURCE_SPECIFICATION)
         read_quality = parse_read_quality_from_fastp(FASTP_PATH)
 
         strategy = system.create_fast_assembly_strategy(read_quality)
@@ -84,7 +86,7 @@ class TestExpertSystem:
         DATABASE_PATH = os.path.join(Path(__file__).parent.parent.absolute(), "proksee", "database",
                                      "refseq_short.csv")
 
-        system = ExpertSystem(platform, species, reads, OUTPUT_DIR)
+        system = ExpertSystem(platform, species, reads, OUTPUT_DIR, RESOURCE_SPECIFICATION)
         assembly_quality = parse_assembly_quality_from_quast_report(QUAST_FILENAME)
         database = AssemblyDatabase(DATABASE_PATH)
 
@@ -106,7 +108,7 @@ class TestExpertSystem:
         DATABASE_PATH = os.path.join(Path(__file__).parent.parent.absolute(), "proksee", "database",
                                      "refseq_short.csv")
 
-        system = ExpertSystem(platform, species, reads, OUTPUT_DIR)
+        system = ExpertSystem(platform, species, reads, OUTPUT_DIR, RESOURCE_SPECIFICATION)
         assembly_quality = parse_assembly_quality_from_quast_report(QUAST_FILENAME)
         database = AssemblyDatabase(DATABASE_PATH)
 
@@ -128,7 +130,7 @@ class TestExpertSystem:
         DATABASE_PATH = os.path.join(Path(__file__).parent.parent.absolute(), "proksee", "database",
                                      "refseq_short.csv")
 
-        system = ExpertSystem(platform, species, reads, OUTPUT_DIR)
+        system = ExpertSystem(platform, species, reads, OUTPUT_DIR, RESOURCE_SPECIFICATION)
         assembly_quality = parse_assembly_quality_from_quast_report(QUAST_FILENAME)
         database = AssemblyDatabase(DATABASE_PATH)
 
@@ -150,7 +152,7 @@ class TestExpertSystem:
         DATABASE_PATH = os.path.join(Path(__file__).parent.parent.absolute(), "proksee", "database",
                                      "refseq_short.csv")
 
-        system = ExpertSystem(platform, species, reads, OUTPUT_DIR)
+        system = ExpertSystem(platform, species, reads, OUTPUT_DIR, RESOURCE_SPECIFICATION)
         assembly_quality = parse_assembly_quality_from_quast_report(QUAST_FILENAME)
         database = AssemblyDatabase(DATABASE_PATH)
 

--- a/tests/test_skesa_assembler.py
+++ b/tests/test_skesa_assembler.py
@@ -23,9 +23,11 @@ from pathlib import Path
 
 from proksee.reads import Reads
 from proksee.skesa_assembler import SkesaAssembler
+from proksee.resource_specification import ResourceSpecification
 
 INPUT_DIR = os.path.join(Path(__file__).parent.absolute(), "data")
 OUTPUT_DIR = os.path.join(Path(__file__).parent.absolute(), "output")
+RESOURCE_SPECIFICATION = ResourceSpecification(4, 4)  # 4 threads, 4 gigabytes
 
 
 class TestSkesaAssembler:
@@ -39,7 +41,7 @@ class TestSkesaAssembler:
         reverse_filename = None
         reads = Reads(forward_filename, reverse_filename)
 
-        assembler = SkesaAssembler(reads, OUTPUT_DIR)
+        assembler = SkesaAssembler(reads, OUTPUT_DIR, RESOURCE_SPECIFICATION)
         contigs_filename = assembler.get_contigs_filename()
 
         # Remove previous assembly if it exists:
@@ -60,7 +62,7 @@ class TestSkesaAssembler:
         reverse_filename = os.path.join(INPUT_DIR, "NA12878_rev.fastq")
         reads = Reads(forward_filename, reverse_filename)
 
-        assembler = SkesaAssembler(reads, OUTPUT_DIR)
+        assembler = SkesaAssembler(reads, OUTPUT_DIR, RESOURCE_SPECIFICATION)
         contigs_filename = assembler.get_contigs_filename()
 
         # Remove previous assembly if it exists:
@@ -82,7 +84,7 @@ class TestSkesaAssembler:
         reads = Reads(forward_filename, reverse_filename)
 
         with pytest.raises(FileNotFoundError):
-            SkesaAssembler(reads, OUTPUT_DIR)
+            SkesaAssembler(reads, OUTPUT_DIR, RESOURCE_SPECIFICATION)
 
     def test_bad_file(self):
         """
@@ -97,7 +99,7 @@ class TestSkesaAssembler:
         reverse_filename = None
         reads = Reads(forward_filename, reverse_filename)
 
-        assembler = SkesaAssembler(reads, OUTPUT_DIR)
+        assembler = SkesaAssembler(reads, OUTPUT_DIR, RESOURCE_SPECIFICATION)
 
         with pytest.raises(SystemExit):
             assembler.assemble()

--- a/tests/test_spades_assembler.py
+++ b/tests/test_spades_assembler.py
@@ -23,9 +23,11 @@ from pathlib import Path
 
 from proksee.reads import Reads
 from proksee.spades_assembler import SpadesAssembler
+from proksee.resource_specification import ResourceSpecification
 
 INPUT_DIR = os.path.join(Path(__file__).parent.absolute(), "data")
 OUTPUT_DIR = TEST_INPUT_DIR = os.path.join(Path(__file__).parent.absolute(), "output")
+RESOURCE_SPECIFICATION = ResourceSpecification(4, 4)  # 4 threads, 4 gigabytes
 
 
 class TestSpadesAssembler:
@@ -39,7 +41,7 @@ class TestSpadesAssembler:
         reverse_filename = None
         reads = Reads(forward_filename, reverse_filename)
 
-        assembler = SpadesAssembler(reads, OUTPUT_DIR)
+        assembler = SpadesAssembler(reads, OUTPUT_DIR, RESOURCE_SPECIFICATION)
         contigs_filename = assembler.get_contigs_filename()
 
         # Remove previous assembly if it exists:
@@ -60,7 +62,7 @@ class TestSpadesAssembler:
         reverse_filename = os.path.join(INPUT_DIR, "NA12878_rev.fastq")
         reads = Reads(forward_filename, reverse_filename)
 
-        assembler = SpadesAssembler(reads, OUTPUT_DIR)
+        assembler = SpadesAssembler(reads, OUTPUT_DIR, RESOURCE_SPECIFICATION)
         contigs_filename = assembler.get_contigs_filename()
 
         # Remove previous assembly if it exists:
@@ -82,7 +84,7 @@ class TestSpadesAssembler:
         reads = Reads(forward_filename, reverse_filename)
 
         with pytest.raises(FileNotFoundError):
-            SpadesAssembler(reads, OUTPUT_DIR)
+            SpadesAssembler(reads, OUTPUT_DIR, RESOURCE_SPECIFICATION)
 
     def test_bad_file(self):
         """
@@ -97,7 +99,7 @@ class TestSpadesAssembler:
         reverse_filename = None
         reads = Reads(forward_filename, reverse_filename)
 
-        assembler = SpadesAssembler(reads, OUTPUT_DIR)
+        assembler = SpadesAssembler(reads, OUTPUT_DIR, RESOURCE_SPECIFICATION)
 
         with pytest.raises(SystemExit):
             assembler.assemble()


### PR DESCRIPTION
This pull request adds basic resource specification to the command line options of `proksee assemble`:

- `-t` and `--threads` for the number of the threads
- `-m` and `--memory` for the amount of memory in gigabytes

I created a new class called `ResourceSpecification`, which gets passed around to classes that care about resources (currently the assemblers). In the future, if needed, it should be very straight-forward to add more resource specification options using this object.