### PR TITLE
Setting quast=5.0.2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
 - fastp
 - skesa
 - mash
-- quast
+- quast=5.0.2
 - scipy
 - spades
 - wget


### PR DESCRIPTION
Quast was updated to version 5.2 on June 7, 2022. As far as I understand, there were [some changes made to the quast output files](https://github.com/ablab/quast/releases/tag/quast_5.2.0), which is creating problems when parsing within Proksee, since we currently do not fix the version of quast in our environment file.

However, I don't expect this to be causing problems with our release Proksee through Bioconda, since it [appears quast is already fixed to 5.0.2](https://github.com/bioconda/bioconda-recipes/blob/master/recipes/proksee/meta.yaml).