### PR TITLE
Various small fixes for v1.0.0a5

### DIFF
--- a/proksee/assembly_measurer.py
+++ b/proksee/assembly_measurer.py
@@ -81,7 +81,7 @@ class AssemblyMeasurer:
             raise FileNotFoundError("File not found: " + self.contigs_filename)
 
         quast_command = "quast --contig-thresholds 0," + str(self.minimum_contig_length) + \
-                        " --min-contig " + + str(self.minimum_contig_length) + " " + \
+                        " --min-contig " + str(self.minimum_contig_length) + " " + \
                         self.contigs_filename + " -o " + self.quast_directory
         quast_out = open(os.path.join(self.output_directory, self.OUTPUT_FILENAME), "w+")
         quast_err = open(os.path.join(self.output_directory, self.ERROR_FILENAME), "w+")

--- a/proksee/assembly_measurer.py
+++ b/proksee/assembly_measurer.py
@@ -80,7 +80,8 @@ class AssemblyMeasurer:
         if not os.path.exists(self.contigs_filename):
             raise FileNotFoundError("File not found: " + self.contigs_filename)
 
-        quast_command = "quast --contig-thresholds 0," + str(self.minimum_contig_length) + " " + \
+        quast_command = "quast --contig-thresholds 0," + str(self.minimum_contig_length) + \
+                        " --min-contig " + + str(self.minimum_contig_length) + " " + \
                         self.contigs_filename + " -o " + self.quast_directory
         quast_out = open(os.path.join(self.output_directory, self.OUTPUT_FILENAME), "w+")
         quast_err = open(os.path.join(self.output_directory, self.ERROR_FILENAME), "w+")

--- a/proksee/commands/cmd_assemble.py
+++ b/proksee/commands/cmd_assemble.py
@@ -199,11 +199,11 @@ def determine_platform(reads, platform_name=None):
               help="The species to assemble. This will override species estimation. Must be spelled correctly.")
 @click.option('-p', '--platform', required=False, default=None,
               help="The sequencing platform used to generate the reads. 'Illumina', 'Ion Torrent', or 'Pac Bio'.")
-@click.option('--min-contig-length', required=False, default=1000,
+@click.option('--min-contig-length', required=False, default=1000, type=int,
               help="The minimum contig length to include in analysis and output. The default is 1000.")
-@click.option('-t', '--threads', required=False, default=4,
+@click.option('-t', '--threads', required=False, default=4, type=int,
               help="Specifies the number of threads programs in the pipeline should use. The default is 4.")
-@click.option('-m', '--memory', required=False, default=4,
+@click.option('-m', '--memory', required=False, default=4, type=int,
               help="Specifies the amount of memory in gigabytes programs in the pipeline should use. The default is 4")
 @click.pass_context
 def cli(ctx, forward, reverse, output, force, species, platform, min_contig_length, threads, memory):

--- a/proksee/commands/cmd_assemble.py
+++ b/proksee/commands/cmd_assemble.py
@@ -200,11 +200,11 @@ def determine_platform(reads, platform_name=None):
               help="The species to assemble. This will override species estimation. Must be spelled correctly.")
 @click.option('-p', '--platform', required=False, default=None,
               help="The sequencing platform used to generate the reads. 'Illumina', 'Ion Torrent', or 'Pac Bio'.")
-@click.option('--min-contig-length', required=False, default=1000, type=click.IntRange(min=0, max=None),
+@click.option('--min-contig-length', required=False, default=1000, type=click.IntRange(min=1, max=None),
               help="The minimum contig length to include in analysis and output. The default is 1000.")
-@click.option('-t', '--threads', required=False, default=4, type=click.IntRange(min=0, max=None),
+@click.option('-t', '--threads', required=False, default=4, type=click.IntRange(min=1, max=None),
               help="Specifies the number of threads programs in the pipeline should use. The default is 4.")
-@click.option('-m', '--memory', required=False, default=4, type=click.IntRange(min=0, max=None),
+@click.option('-m', '--memory', required=False, default=4, type=click.IntRange(min=1, max=None),
               help="Specifies the amount of memory in gigabytes programs in the pipeline should use. The default is 4")
 @click.pass_context
 def cli(ctx, forward, reverse, output, force, species, platform, min_contig_length, threads, memory):
@@ -293,7 +293,7 @@ def assemble(reads, output_directory, force, mash_database_path, resource_specif
         output_directory (string): the location to place all program output and temporary files
         force (bool): whether or not to force the assembly to continue, even when it's evaluated as being poor
         mash_database_path (string): optional; the file path of the Mash database
-        resource_specification (ResourceSpecification): the resources that sub-programs should use
+        resource_specification (ResourceSpecification): the computational resources available
         species_name (string): optional; the name of the species being assembled
         platform_name (string): optional; the name of the sequencing platform that generated the reads
         minimum_contig_length (int): optional; the minimum contig length to use for assembly and analysis
@@ -332,7 +332,7 @@ def assemble(reads, output_directory, force, mash_database_path, resource_specif
     filtered_filenames = filtered_reads.get_file_locations()
     species_list = utilities.determine_major_species(filtered_filenames, assembly_database, output_directory,
                                                      mash_database_path, id_mapping_filename, InputType.READS,
-                                                     species_name)
+                                                     resource_specification, species_name)
     species = species_list[0]
     report_species(species_list)
 
@@ -351,7 +351,8 @@ def assemble(reads, output_directory, force, mash_database_path, resource_specif
 
     # Check for contamination at the contig level:
     contamination_handler = ContaminationHandler(species, assembler.contigs_filename, output_directory,
-                                                 mash_database_path, id_mapping_filename)
+                                                 mash_database_path, id_mapping_filename,
+                                                 resource_specification)
     evaluation = contamination_handler.estimate_contamination()
     report_contamination(evaluation)
 

--- a/proksee/commands/cmd_assemble.py
+++ b/proksee/commands/cmd_assemble.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from shutil import rmtree
 
 from proksee import utilities
+from proksee.utilities import InputType
 from proksee.assembly_database import AssemblyDatabase
 from proksee.assembly_measurer import AssemblyMeasurer
 from proksee.contamination_handler import ContaminationHandler
@@ -329,8 +330,9 @@ def assemble(reads, output_directory, force, mash_database_path, resource_specif
 
     # Estimate species
     filtered_filenames = filtered_reads.get_file_locations()
-    species_list = utilities.determine_species(filtered_filenames, assembly_database, output_directory,
-                                               mash_database_path, id_mapping_filename, species_name)
+    species_list = utilities.determine_major_species(filtered_filenames, assembly_database, output_directory,
+                                                     mash_database_path, id_mapping_filename, InputType.READS,
+                                                     species_name)
     species = species_list[0]
     report_species(species_list)
 

--- a/proksee/commands/cmd_assemble.py
+++ b/proksee/commands/cmd_assemble.py
@@ -199,11 +199,11 @@ def determine_platform(reads, platform_name=None):
               help="The species to assemble. This will override species estimation. Must be spelled correctly.")
 @click.option('-p', '--platform', required=False, default=None,
               help="The sequencing platform used to generate the reads. 'Illumina', 'Ion Torrent', or 'Pac Bio'.")
-@click.option('--min-contig-length', required=False, default=1000, type=int,
+@click.option('--min-contig-length', required=False, default=1000, type=click.IntRange(min=0, max=None),
               help="The minimum contig length to include in analysis and output. The default is 1000.")
-@click.option('-t', '--threads', required=False, default=4, type=int,
+@click.option('-t', '--threads', required=False, default=4, type=click.IntRange(min=0, max=None),
               help="Specifies the number of threads programs in the pipeline should use. The default is 4.")
-@click.option('-m', '--memory', required=False, default=4, type=int,
+@click.option('-m', '--memory', required=False, default=4, type=click.IntRange(min=0, max=None),
               help="Specifies the amount of memory in gigabytes programs in the pipeline should use. The default is 4")
 @click.pass_context
 def cli(ctx, forward, reverse, output, force, species, platform, min_contig_length, threads, memory):

--- a/proksee/commands/cmd_evaluate.py
+++ b/proksee/commands/cmd_evaluate.py
@@ -32,6 +32,7 @@ from proksee.machine_learning_evaluator import MachineLearningEvaluator
 import proksee.config as config
 from proksee.ncbi_assembly_evaluator import NCBIAssemblyEvaluator
 from proksee.species_assembly_evaluator import SpeciesAssemblyEvaluator
+from proksee.resource_specification import ResourceSpecification
 
 DATABASE_PATH = os.path.join(Path(__file__).parent.parent.absolute(), "database",
                              "refseq_short.csv")
@@ -50,8 +51,12 @@ ID_MAPPING_FILENAME = os.path.join(Path(__file__).parent.parent.absolute(), "dat
 @click.option('-o', '--output', required=True,
               type=click.Path(exists=False, file_okay=False,
                               dir_okay=True, writable=True))
+@click.option('-t', '--threads', required=False, default=4, type=click.IntRange(min=1, max=None),
+              help="Specifies the number of threads programs in the pipeline should use. The default is 4.")
+@click.option('-m', '--memory', required=False, default=4, type=click.IntRange(min=1, max=None),
+              help="Specifies the amount of memory in gigabytes programs in the pipeline should use. The default is 4")
 @click.pass_context
-def cli(ctx, contigs, species, min_contig_length, output):
+def cli(ctx, contigs, species, min_contig_length, output, threads, memory):
 
     # Check Mash database is installed:
     mash_database_path = config.get(config.MASH_PATH)
@@ -60,10 +65,11 @@ def cli(ctx, contigs, species, min_contig_length, output):
         print("Please run 'proksee updatedb' to install the databases!")
         return
 
-    evaluate(contigs, output, mash_database_path, species, min_contig_length)
+    resource_specification = ResourceSpecification(threads, memory)
+    evaluate(contigs, output, resource_specification, mash_database_path, species, min_contig_length)
 
 
-def evaluate(contigs_filename, output_directory, mash_database_path,
+def evaluate(contigs_filename, output_directory, resource_specification, mash_database_path,
              species_name=None, minimum_contig_length=1000, id_mapping_filename=ID_MAPPING_FILENAME):
     """
     The main control flow of the program that evaluates the assembly.
@@ -71,6 +77,7 @@ def evaluate(contigs_filename, output_directory, mash_database_path,
     ARGUMENTS:
         contigs_filename (string): the filename of the contigs to evaluate
         output_directory (string): the location to place all program output and temporary files
+        resource_specification (ResourceSpecification): the computational resources available
         mash_database_path (string): optional; the name of the Mash database
         species_name (string): optional; the name of the species being assembled
         minimum_contig_length (int): optional; the minimum contig length to consider for analysis
@@ -92,7 +99,7 @@ def evaluate(contigs_filename, output_directory, mash_database_path,
     # Estimate species
     species_list = utilities.determine_major_species([contigs_filename], assembly_database, output_directory,
                                                      mash_database_path, id_mapping_filename, InputType.ASSEMBLY,
-                                                     species_name)
+                                                     resource_specification, species_name)
     species = species_list[0]
     click.echo("The identified species is: " + str(species.name) + "\n")
 

--- a/proksee/commands/cmd_evaluate.py
+++ b/proksee/commands/cmd_evaluate.py
@@ -24,6 +24,7 @@ import os
 from pathlib import Path
 
 from proksee import utilities
+from proksee.utilities import InputType
 from proksee.assembly_database import AssemblyDatabase
 from proksee.assembly_measurer import AssemblyMeasurer
 from proksee.machine_learning_evaluator import MachineLearningEvaluator
@@ -89,8 +90,9 @@ def evaluate(contigs_filename, output_directory, mash_database_path,
     assembly_database = AssemblyDatabase(DATABASE_PATH)
 
     # Estimate species
-    species_list = utilities.determine_species([contigs_filename], assembly_database, output_directory,
-                                               mash_database_path, id_mapping_filename, species_name)
+    species_list = utilities.determine_major_species([contigs_filename], assembly_database, output_directory,
+                                                     mash_database_path, id_mapping_filename, InputType.ASSEMBLY,
+                                                     species_name)
     species = species_list[0]
     click.echo("The identified species is: " + str(species.name) + "\n")
 

--- a/proksee/commands/cmd_updatedb.py
+++ b/proksee/commands/cmd_updatedb.py
@@ -82,7 +82,7 @@ def update(directory):
 
         click.echo("Downloading database...")
 
-        command = "wget -O " + str(mash_database_path) + " " + MASH_DATABASE_URL
+        command = "wget -O " + str(mash_database_path) + " " + MASH_DATABASE_URL + " --progress=dot:giga"
 
         try:
             subprocess.check_call(command, shell=True)

--- a/proksee/contamination_handler.py
+++ b/proksee/contamination_handler.py
@@ -36,11 +36,13 @@ class ContaminationHandler:
             subdirectory of the program output directory
         mash_database_filename (str): the filename of the Mash sketch (database)
         id_mapping_filename (str): filename of the NCBI ID-to-taxonomy mapping file
+        resource_specification (ResourceSpecification): the computational resources available
     """
 
     FASTA_DIRECTORY = "fasta"
 
-    def __init__(self, species, contigs_file, output_directory, mash_database_filename, id_mapping_filename):
+    def __init__(self, species, contigs_file, output_directory, mash_database_filename, id_mapping_filename,
+                 resource_specification):
         """
         Initializes the contamination handler.
 
@@ -50,6 +52,7 @@ class ContaminationHandler:
             output_directory (str): the output directory for the program
             mash_database_filename (str): the filename of the Mash sketch (database)
             id_mapping_filename (str): filename of the NCBI ID-to-taxonomy mapping file
+            resource_specification (ResourceSpecification): the computational resources available
         """
 
         self.species = species
@@ -57,6 +60,7 @@ class ContaminationHandler:
         self.output_directory = output_directory
         self.mash_database_filename = mash_database_filename
         self.id_mapping_filename = id_mapping_filename
+        self.resource_specification = resource_specification
 
     def estimate_contamination(self):
         """
@@ -124,7 +128,8 @@ class ContaminationHandler:
         for i in range(len(contig_filenames)):
 
             species_estimator = SpeciesEstimator(contig_filenames[i], self.output_directory,
-                                                 self.mash_database_filename, self.id_mapping_filename)
+                                                 self.mash_database_filename, self.id_mapping_filename,
+                                                 self.resource_specification)
             species_list = species_estimator.estimate_all_species()
 
             contig_species.append(species_list[0])  # Select the estimation with the most evidence

--- a/proksee/contamination_handler.py
+++ b/proksee/contamination_handler.py
@@ -68,6 +68,34 @@ class ContaminationHandler:
                 contains an associated, plain-language report
         """
 
+        # The single FASTA file containing multiple contigs (self.contigs_file) is first
+        # split into multiple single contig FASTA files, which are all placed in the
+        # newly created `fasta_directory`.
+        #
+        # Next, a number of chunks / lists are created. The single contig FASTA files
+        # are listed in descending order by contig size and this allows for (usually)
+        # an even distribution of contigs by size into the different chunks / lists.
+        # Single contig FASTA files are added to each chunk by rotating the lists and
+        # added the next largest contig. At the end of this step, there should be a
+        # number of lists equal to the number of chunks, and each list should contain
+        # a similar amount of sequence.
+        #
+        # Finally, the species of each chunk / list is evaluated independently. This
+        # will consider all of the single contig FASTA files in the chunk together
+        # when estimating a species. For example, if there are 5 chunks, each will
+        # contain approxately 1/5th of the total assembly sequence, and each 1/5th
+        # will be given a species estimation. These 5 species estimations will then be
+        # compared with each other and the provided species to see if there's any
+        # discrepancey. What this accomplishes is distributing the entire collection
+        # of assembled contigs into 5 different chunks, estimating the species of
+        # each chunk, and ensuring that each chunk still provides the same species
+        # estimation.
+        #
+        # The motivation is that with that right number of chunks (accounting for
+        # computational time), we should observe if a large contiminate contig has
+        # been assembled, because it will disagree with the other chunks and the
+        # provided species.
+
         CHUNKS = 5
 
         fasta_directory = os.path.join(self.output_directory, self.FASTA_DIRECTORY)

--- a/proksee/species_estimator.py
+++ b/proksee/species_estimator.py
@@ -169,11 +169,11 @@ class SpeciesEstimator:
         for item in self.input_list:
             command += " " + str(item)
 
-            # Break loop of command line argument is getting too long.
+            # Break loop if command line argument is getting too long.
             # This behaviour is likely fine for now, since the contigs are organized by size
             # and the missed contigs will likely be uninformative.
             if len(command) >= LINE_LENGTH_LIMIT:
-                continue
+                break
 
         command += " | sort -gr > " + output_filepath
 

--- a/proksee/species_estimator.py
+++ b/proksee/species_estimator.py
@@ -167,7 +167,9 @@ class SpeciesEstimator:
         command = "mash screen -i 0 -v 1 " + self.mash_database_filename
 
         for item in self.input_list:
-            command += " " + str(item)
+            # Since we will run relative to the output directory,
+            # grab only the file basename of each input filepath, not the full path:
+            command += " " + str(os.path.basename(item))
 
             # Break loop if command line argument is getting too long.
             # This behaviour is likely fine for now, since the contigs are organized by size
@@ -175,13 +177,15 @@ class SpeciesEstimator:
             if len(command) >= LINE_LENGTH_LIMIT:
                 break
 
-        command += " | sort -gr > " + output_filepath
+        # Basename because we're running realitive to the output directory:
+        command += " | sort -gr > " + os.path.basename(output_filepath)
 
         # run mash
         try:
-            subprocess.run(command, capture_output=True, shell=True, encoding="utf8")
+            # Run relative to the output directory so that filepaths are shorter:
+            subprocess.run(command, capture_output=True, shell=True, encoding="utf8", cwd=self.output_directory)
 
         except subprocess.CalledProcessError:
-            pass  # it will be the responsibility of the calling function to insure there was output
+            pass  # it will be the responsibility of the calling function to ensure there was output
 
         return output_filepath

--- a/proksee/species_estimator.py
+++ b/proksee/species_estimator.py
@@ -176,7 +176,9 @@ class SpeciesEstimator:
         else:
             # The common path is NOT a directory.
             # This can happen when there is only a single input (the common path is the single file's filepath).
-            common_directory = os.path.dirname(common_path)
+            # We need to take the absolute path first, because some relative paths (ex: "contigs.fa") will return
+            # an empty string for the dirname.
+            common_directory = os.path.dirname(os.path.abspath(common_path))
 
         # create the mash command
         # Use the full file path for the database file:

--- a/proksee/species_estimator.py
+++ b/proksee/species_estimator.py
@@ -78,11 +78,13 @@ class SpeciesEstimator:
         output_directory (str): the directory to use for output
         mash_database_filename (str): the filename of the Mash database
         id_mapping_filename (str): filename of the NCBI ID-to-taxonomy mapping file
+        resource_specification (ResourceSpecification): the computational resources available
     """
 
     OUTPUT_FILENAME = "mash.o"
 
-    def __init__(self, input_list, output_directory, mash_database_filename, id_mapping_filename):
+    def __init__(self, input_list, output_directory, mash_database_filename, id_mapping_filename,
+                 resource_specification):
         """
         Initializes the species estimator.
 
@@ -91,12 +93,14 @@ class SpeciesEstimator:
             output_directory (str): the directory to use for program output
             mash_database_filename (str): the filename of the Mash database
             id_mapping_filename (str): filename of the NCBI ID-to-taxonomy mapping file
+            resource_specification (ResourceSpecification): the computational resources available
         """
 
         self.input_list = [i for i in input_list if i]  # remove all "None" inputs
         self.output_directory = output_directory
         self.mash_database_filename = mash_database_filename
         self.id_mapping_filename = id_mapping_filename
+        self.resource_specification = resource_specification
 
     def estimate_major_species_from_reads(self):
         """
@@ -203,7 +207,8 @@ class SpeciesEstimator:
 
         # create the mash command
         # Use the full file path for the database file:
-        command = ["mash", "screen", "-i", "0", "-v", "1", self.mash_database_filename]
+        threads = self.resource_specification.threads
+        command = ["mash", "screen", "-p", str(threads), "-i", "0", "-v", "1", self.mash_database_filename]
 
         total_filepath_length = 0  # The total length of all characters in all filepaths
         total_contigs = 0

--- a/proksee/utilities.py
+++ b/proksee/utilities.py
@@ -35,7 +35,7 @@ class InputType(Enum):
 
 
 def determine_major_species(input_filenames, assembly_database, output_directory, mash_database_filename,
-                            id_mapping_filename, input_type, species_name=None):
+                            id_mapping_filename, input_type, resource_specification, species_name=None):
     """
     Attempts to determine the species in the input (reads or assembly).
 
@@ -46,6 +46,7 @@ def determine_major_species(input_filenames, assembly_database, output_directory
         mash_database_filename (string): the filename of the Mash sketch (database) file
         id_mapping_filename (string): the filename of the NCBI ID-to-taxonomy mapping file
         input_type (InputType): InputType.READS or InputType.ASSEMBLY
+        resource_specification (ResourceSpecification): the computational resources that can be used
         species_name (string): optional; the scientific name of the species
 
     RETURNS:
@@ -64,7 +65,7 @@ def determine_major_species(input_filenames, assembly_database, output_directory
 
     if species_list is None:
         species_estimator = SpeciesEstimator(input_filenames, output_directory, mash_database_filename,
-                                             id_mapping_filename)
+                                             id_mapping_filename, resource_specification)
         if input_type == InputType.READS:
             click.echo("\nAttempting to identify the species from the reads.")
             species_list = species_estimator.estimate_major_species_from_reads()

--- a/proksee/utilities.py
+++ b/proksee/utilities.py
@@ -26,11 +26,18 @@ from proksee.database.version import MODEL_VERSION, NORM_DATABASE_VERSION
 from proksee.species import Species
 from proksee.species_estimator import SpeciesEstimator
 
+from enum import Enum
 
-def determine_species(input_filenames, assembly_database, output_directory, mash_database_filename,
-                      id_mapping_filename, species_name=None):
+
+class InputType(Enum):
+    READS = "Reads"
+    ASSEMBLY = "Assembly"
+
+
+def determine_major_species(input_filenames, assembly_database, output_directory, mash_database_filename,
+                            id_mapping_filename, input_type, species_name=None):
     """
-    Attempts to determine the species in the input (reads or contigs).
+    Attempts to determine the species in the input (reads or assembly).
 
     ARGUMENTS:
         input_filenames (List(string)): the inputs (filenames) from which to determine the species from
@@ -38,6 +45,7 @@ def determine_species(input_filenames, assembly_database, output_directory, mash
         output_directory (string): the location of the output directory for placing temporary output
         mash_database_filename (string): the filename of the Mash sketch (database) file
         id_mapping_filename (string): the filename of the NCBI ID-to-taxonomy mapping file
+        input_type (InputType): InputType.READS or InputType.ASSEMBLY
         species_name (string): optional; the scientific name of the species
 
     RETURNS:
@@ -55,11 +63,15 @@ def determine_species(input_filenames, assembly_database, output_directory, mash
             click.echo("\nThe species name '" + str(species_name) + "' is unrecognized.")
 
     if species_list is None:
-        click.echo("\nAttempting to identify the species from the input.")
-
         species_estimator = SpeciesEstimator(input_filenames, output_directory, mash_database_filename,
                                              id_mapping_filename)
-        species_list = species_estimator.estimate_major_species()
+        if input_type == InputType.READS:
+            click.echo("\nAttempting to identify the species from the reads.")
+            species_list = species_estimator.estimate_major_species_from_reads()
+
+        elif input_type == InputType.ASSEMBLY:
+            click.echo("\nAttempting to identify the species from the assembly.")
+            species_list = species_estimator.estimate_major_species_from_assembly()
 
     return species_list
 

--- a/tests/test_cmd_evaluate.py
+++ b/tests/test_cmd_evaluate.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 from proksee.commands.cmd_evaluate import evaluate
 import proksee.config as config
+from proksee.resource_specification import ResourceSpecification
 
 INPUT_DIR = os.path.join(Path(__file__).parent.absolute(), "data")
 OUTPUT_DIR = os.path.join(Path(__file__).parent.absolute(), "output")
@@ -46,8 +47,9 @@ class TestCmdEvaluate:
         if os.path.isfile(quast_file):
             os.remove(quast_file)
 
+        resource_specification = ResourceSpecification(4, 4)
         mash_database_path = config.get(config.MASH_PATH)
-        evaluate(contigs_filename, OUTPUT_DIR, mash_database_path, species_name=None)
+        evaluate(contigs_filename, OUTPUT_DIR, resource_specification, mash_database_path, species_name=None)
 
         # Check that expected files were created:
         assert os.path.isfile(quast_file)

--- a/tests/test_contamination_handler.py
+++ b/tests/test_contamination_handler.py
@@ -22,6 +22,8 @@ from pathlib import Path
 
 from proksee.contamination_handler import ContaminationHandler
 from proksee.species import Species
+from proksee.resource_specification import ResourceSpecification
+
 
 TEST_MASH_DB_FILENAME = os.path.join(Path(__file__).parent.absolute(), "data", "ecoli.msh")
 TEST_ID_MAPPING_FILENAME = os.path.join(Path(__file__).parent.absolute(), "data", "test_id_mapping.tab")
@@ -34,8 +36,10 @@ class TestContaminationHandler:
         species = Species("Boletus subalpinus", 1.0)
         contigs_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data", "ecoli_mini.fasta")
         output_directory = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data", "testout")
+        resource_specification = ResourceSpecification(4, 4)
         handler = ContaminationHandler(species, contigs_file, output_directory,
-                                       TEST_MASH_DB_FILENAME, TEST_ID_MAPPING_FILENAME)
+                                       TEST_MASH_DB_FILENAME, TEST_ID_MAPPING_FILENAME,
+                                       resource_specification)
 
         evaluation = handler.estimate_contamination()
 
@@ -56,8 +60,10 @@ class TestContaminationHandler:
         species = Species("Escherichia coli", 1.0)
         contigs_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data", "ecoli_mini.fasta")
         output_directory = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data", "testout")
+        resource_specification = ResourceSpecification(4, 4)
         handler = ContaminationHandler(species, contigs_file, output_directory,
-                                       TEST_MASH_DB_FILENAME, TEST_ID_MAPPING_FILENAME)
+                                       TEST_MASH_DB_FILENAME, TEST_ID_MAPPING_FILENAME,
+                                       resource_specification)
 
         evaluation = handler.estimate_contamination()
 
@@ -74,8 +80,10 @@ class TestContaminationHandler:
         species = Species("Staphylococcus pseudintermedius", 1.0)
         contigs_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data", "simple_contig.fasta")
         output_directory = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data", "testout")
+        resource_specification = ResourceSpecification(4, 4)
         handler = ContaminationHandler(species, contigs_file, output_directory,
-                                       TEST_MASH_DB_FILENAME, TEST_ID_MAPPING_FILENAME)
+                                       TEST_MASH_DB_FILENAME, TEST_ID_MAPPING_FILENAME,
+                                       resource_specification)
 
         evaluation = handler.estimate_contamination()
         print(evaluation.report)

--- a/tests/test_species_estimator.py
+++ b/tests/test_species_estimator.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 from proksee.parser.mash_parser import MashParser
 from proksee.species_estimator import estimate_species_from_estimations, SpeciesEstimator
+from proksee.resource_specification import ResourceSpecification
 
 TEST_MASH_DB_FILENAME = os.path.join(Path(__file__).parent.absolute(), "data", "ecoli.msh")
 TEST_ID_MAPPING_FILENAME = os.path.join(Path(__file__).parent.absolute(), "data", "test_id_mapping.tab")
@@ -58,9 +59,11 @@ class TestSpeciesEstimator:
             os.path.abspath(__file__)), "data", "ecoli_mini.fasta")
         output_directory = os.path.join(os.path.dirname(
             os.path.abspath(__file__)), "data", "temp")
+        resource_specification = ResourceSpecification(4, 4)
 
         estimator = SpeciesEstimator([input_filename], output_directory,
-                                     TEST_MASH_DB_FILENAME, TEST_ID_MAPPING_FILENAME)
+                                     TEST_MASH_DB_FILENAME, TEST_ID_MAPPING_FILENAME,
+                                     resource_specification)
         species_list = estimator.estimate_all_species()
 
         top_species = species_list[0]
@@ -78,11 +81,13 @@ class TestSpeciesEstimator:
             os.path.abspath(__file__)), "data", "ecoli_mini.fasta")
         output_directory = os.path.join(os.path.dirname(
             os.path.abspath(__file__)), "data", "temp")
+        resource_specification = ResourceSpecification(4, 4)
 
         # Creating the estimator with 500 copies of the same input file.
         # This will result in an argument list that is too many characters long. (i.e. >3500)
         estimator = SpeciesEstimator([input_filename] * 500, output_directory,
-                                     TEST_MASH_DB_FILENAME, TEST_ID_MAPPING_FILENAME)
+                                     TEST_MASH_DB_FILENAME, TEST_ID_MAPPING_FILENAME,
+                                     resource_specification)
         species_list = estimator.estimate_all_species()
 
         top_species = species_list[0]

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 from proksee.assembly_database import AssemblyDatabase
 from proksee.species import Species
-from proksee.utilities import determine_species
+from proksee.utilities import InputType, determine_major_species
 
 INPUT_DIR = os.path.join(Path(__file__).parent.absolute(), "data")
 OUTPUT_DIR = os.path.join(Path(__file__).parent.absolute(), "output")
@@ -43,8 +43,9 @@ class TestUtilities:
         database = AssemblyDatabase(DATABASE_PATH)
         species_name = "Escherichia coli"
 
-        species_list = determine_species(input_filenames, database, OUTPUT_DIR,
-                                         TEST_MASH_DB_FILENAME, TEST_ID_MAPPING_FILENAME, species_name)
+        species_list = determine_major_species(input_filenames, database, OUTPUT_DIR,
+                                               TEST_MASH_DB_FILENAME, TEST_ID_MAPPING_FILENAME,
+                                               InputType.ASSEMBLY, species_name)
         assert (species_list[0] == Species("Escherichia coli", 1.0))
 
     def test_determine_species_provided_absent(self):
@@ -59,8 +60,9 @@ class TestUtilities:
         database = AssemblyDatabase(DATABASE_PATH)
         species_name = "TYPO! Escherichia coli"
 
-        species_list = determine_species(input_filenames, database, OUTPUT_DIR,
-                                         TEST_MASH_DB_FILENAME, TEST_ID_MAPPING_FILENAME, species_name)
+        species_list = determine_major_species(input_filenames, database, OUTPUT_DIR,
+                                               TEST_MASH_DB_FILENAME, TEST_ID_MAPPING_FILENAME,
+                                               InputType.ASSEMBLY, species_name)
 
         # Tries to find species when name missing:
         # The problem here, is it will find "Unknown", because the test data file isn't large enough

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from proksee.assembly_database import AssemblyDatabase
 from proksee.species import Species
 from proksee.utilities import InputType, determine_major_species
+from proksee.resource_specification import ResourceSpecification
 
 INPUT_DIR = os.path.join(Path(__file__).parent.absolute(), "data")
 OUTPUT_DIR = os.path.join(Path(__file__).parent.absolute(), "output")
@@ -41,11 +42,12 @@ class TestUtilities:
 
         input_filenames = [os.path.join(INPUT_DIR, "ecoli_mini.fasta")]
         database = AssemblyDatabase(DATABASE_PATH)
+        resource_specification = ResourceSpecification(4, 4)
         species_name = "Escherichia coli"
 
         species_list = determine_major_species(input_filenames, database, OUTPUT_DIR,
                                                TEST_MASH_DB_FILENAME, TEST_ID_MAPPING_FILENAME,
-                                               InputType.ASSEMBLY, species_name)
+                                               InputType.ASSEMBLY, resource_specification, species_name)
         assert (species_list[0] == Species("Escherichia coli", 1.0))
 
     def test_determine_species_provided_absent(self):
@@ -58,11 +60,12 @@ class TestUtilities:
 
         input_filenames = [os.path.join(INPUT_DIR, "ecoli_mini.fasta")]
         database = AssemblyDatabase(DATABASE_PATH)
+        resource_specification = ResourceSpecification(4, 4)
         species_name = "TYPO! Escherichia coli"
 
         species_list = determine_major_species(input_filenames, database, OUTPUT_DIR,
                                                TEST_MASH_DB_FILENAME, TEST_ID_MAPPING_FILENAME,
-                                               InputType.ASSEMBLY, species_name)
+                                               InputType.ASSEMBLY, resource_specification, species_name)
 
         # Tries to find species when name missing:
         # The problem here, is it will find "Unknown", because the test data file isn't large enough


### PR DESCRIPTION
- Modified updatedb's wget to write less to stdout.
- Made sure quast uses the specified contig size.
- "continue" -> "break" when considering mash command size
- Changes the directory mash runs from to reduce to length of file paths.